### PR TITLE
Terminate process when no config is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign reviewers to a pull request based on files changed
-        uses: necojackarc/request-review-based-on-files@v0.0.1
+        uses: necojackarc/request-review-based-on-files@v0.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: .github/reviewers.yml

--- a/dist/index.js
+++ b/dist/index.js
@@ -11915,30 +11915,41 @@ const config_path = core.getInput('config');
 const octokit = github.getOctokit(token);
 
 async function run() {
-  core.info('Fetch configuration file from the base branch');
-  const config = await fetch_config();
+  core.info('Fetching configuration file from the base branch');
+
+  let config;
+
+  try {
+    config = await fetch_config();
+  } catch (error) {
+    if (error.status === 404) {
+      core.warning('No configuration file is found in the base branch; terminating the process');
+      return;
+    }
+    throw error;
+  }
 
   const title = context.payload.pull_request.title;
   const is_draft = context.payload.pull_request.draft;
 
   if (!should_request_review({ title, is_draft, config })) {
-    core.info('Matched the ignoring rules; skip requesting review');
+    core.info('Matched the ignoring rules; terminating the process');
     return;
   }
 
-  core.info('Fetch changed files in the pull request');
+  core.info('Fetching changed files in the pull request');
   const changed_files = await fetch_changed_files();
 
-  core.info('Identify reviewers based on the changed files and the configuration');
+  core.info('Identifying reviewers based on the changed files and the configuration');
   const author = context.payload.pull_request.user.login;
   const reviewers = identify_reviewers({ config, changed_files, excludes: [ author ] });
 
   if (reviewers.length === 0) {
-    core.info('Matched no reviweres; skip requesting review');
+    core.info('Matched no reviweres; sterminating the process');
     return;
   }
 
-  core.info(`Request review to ${reviewers.join(', ')}`);
+  core.info(`Requesting review to ${reviewers.join(', ')}`);
   await assign_reviewers(reviewers);
 }
 
@@ -11964,7 +11975,7 @@ async function fetch_changed_files() {
   do {
     page += 1;
 
-    const { data: response_body } =  await octokit.pulls.listFiles({
+    const { data: response_body } = await octokit.pulls.listFiles({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "request-review-based-on-files",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "request-review-based-on-files",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "GitHub Action that automatically requests review of a pull request based on files changed",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Resolve #12

Instead of letting the entire process just fail, terminate the process with a warning.